### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -1,0 +1,31 @@
+# melpazoid <https://github.com/riscy/melpazoid> build checks.
+
+# If your package is on GitHub, enable melpazoid's checks by copying this file
+# to .github/workflows/melpazoid.yml and modifying RECIPE and EXIST_OK below.
+
+name: melpazoid
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        sudo apt-get install emacs && emacs --version
+        git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+        pip install ~/melpazoid
+    - name: Run
+      env:
+        LOCAL_REPO: ${{ github.workspace }}
+        # RECIPE is your recipe as written for MELPA:
+        RECIPE: (qwen-chat-shell :repo "Pavinberg/qwen-chat-shell" :fetcher github)
+        # set this to false (or remove it) if the package isn't on MELPA:
+        EXIST_OK: true
+      run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/qwen-chat-shell.el
+++ b/qwen-chat-shell.el
@@ -503,6 +503,7 @@ To create the API-key: https://help.aliyun.com/zh/dashscope/developer-reference/
 ;; Aliasing enables editing as text in babel.
 (defalias 'qwen-chat-shell-mode #'text-mode)
 
+(defvar qwen-chat-shell-mode-map)
 (shell-maker-define-major-mode qwen-chat-shell--config) ; then qwen-chat-shell-mode-map is defined
 
 ;;;###autoload
@@ -1464,7 +1465,7 @@ With prefix REVIEW prompt before sending to LLM."
 (defun qwen-chat-shell--eshell-last-last-command ()
   "Get second to last eshell command."
   (save-excursion
-    (if (string= major-mode "eshell-mode")
+    (if (derived-mode-p 'eshell-mode)
         (let ((cmd-start)
               (cmd-end))
           ;; Find command start and end positions


### PR DESCRIPTION
`qwen-chat-shell.el` with byte-compile using Emacs 29.3:
```
qwen-chat-shell.el:550:18: Warning: reference to free variable `qwen-chat-shell-mode-map'
```

`qwen-chat-shell.el` with [melpazoid](https://github.com/riscy/melpazoid):

```
- qwen-chat-shell.el#L1467: Avoid string comparison to check major-mode; use e.g. `(derived-mode-p 'xyz)`
```